### PR TITLE
Update menu.html

### DIFF
--- a/_includes/menu.html
+++ b/_includes/menu.html
@@ -20,7 +20,7 @@ function printMenu($current)
 <a href="/mailinglists/">Mailing lists</a> :: 
 <a href="/download/">Download</a> :: 
 <a href="/feedback/">Feedback</a> :: 
-<a href="http://gphoto.wiki.sourceforge.net/">Wiki</a> ::
+<a href="http://wiki.archlinux.org/index.php/Digital_Cameras">Wiki</a> ::
 <a href="/links/">Links</a>
 
 {% case include.current %}


### PR DESCRIPTION
This not-entirely-serious proposal is intended to start a discussion of what URL the "wiki" link in the website header _should_ link to.
Should it link to
- http://sourceforge.net/p/gphoto/wiki/
- http://github.com/gphoto/gphoto2/wiki
- http://github.com/gphoto/libgphoto2/wiki
- http://github.com/gphoto/gphoto2-manual/wiki
- http://github.com/gphoto/gphoto.github.io/wiki
- http://wiki.archlinux.org/index.php/Digital_Cameras currently has more useful gphoto2-related content than any of the other options.
- http://gphoto.wiki.sourceforge.net/ (the current URL behind the "wiki" link) says "Whoops, we can't find that page." (a 404 error?)
- or perhaps some other URL?
